### PR TITLE
[PKG-13077] pathvalidate 3.3.1 rebuild for defaults

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,2 +1,3 @@
-upload_channels:
-  - sfe1ed40
+build_env_vars:
+  ANACONDA_ROCKET_ENABLE_PY314 : yes
+  

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -21,8 +21,6 @@ requirements:
     - python
     - setuptools >=64
     - setuptools_scm >=8
-    # https://github.com/thombashi/pathvalidate/blob/master/setup.py#L21
-    - releasecmd
   run:
     - python
 


### PR DESCRIPTION
pathvalidate 3.3.1

**Destination channel:** defaults

### Links

- [PKG-13077]
- [Upstream repository](https://github.com/thombashi/pathvalidate)

### Explanation of changes:

- Previously released on Snowflake channel, rebuilding for defaults
- `releasecmd` is used for uploading to Pypi and is not necessary to build the package


[PKG-13077]: https://anaconda.atlassian.net/browse/PKG-13077?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ